### PR TITLE
net-p2p/cardano-node: Fix build on aarm64

### DIFF
--- a/net-p2p/cardano-node/Makefile
+++ b/net-p2p/cardano-node/Makefile
@@ -51,7 +51,7 @@ do-build:
 	${ECHO} "  extra-lib-dirs: ${LIBSODIUM_PREFIX}${PREFIX}/lib" >> ${WRKSRC}/cabal.project.cardano-node
 	mv ${WRKSRC}/cabal.project.cardano-node ${WRKSRC}/cabal.project
 	cd ${WRKSRC} && env ${CABAL_ENV} cabal configure --with-compiler=ghc-${GHC_VERSION}
-	cd ${WRKSRC} && env ${CABAL_ENV} cabal build all
+	cd ${WRKSRC} && env ${CABAL_ENV} cabal build cardano-node cardano-cli
 
 do-install:
 	cd ${WRKSRC_sodium} && gmake DESTDIR=${STAGEDIR} install

--- a/net-p2p/cardano-node/files/cardano_node.in
+++ b/net-p2p/cardano-node/files/cardano_node.in
@@ -66,7 +66,7 @@ topology_file="${cardano_node_home}/testnet-topology.json"
 config_file="${cardano_node_home}/testnet-config.json"
 pidfile="/var/run/cardano-node.pid"
 logfile="/var/log/cardano-node.log"
-flags=run +RTS -N -A16m -qg -qb -RTS \
+flags=run +RTS -N -A64m -n4m -F1.2 -qg1 -RTS \
         --database-path ${cardano_node_db} \
         --host-addr ${cardano_node_host} \
         --port ${cardano_node_port} \

--- a/net-p2p/cardano-node/files/cardano_node.in
+++ b/net-p2p/cardano-node/files/cardano_node.in
@@ -45,7 +45,6 @@ rcvar=cardano_node_enable
 
 start_cmd="${name}_start"
 start_precmd="${name}_prestart"
-start_postcmd="${name}_poststart"
 stop_cmd="${name}_stop"
 status_cmd="${name}_status"
 
@@ -66,14 +65,14 @@ topology_file="${cardano_node_home}/testnet-topology.json"
 config_file="${cardano_node_home}/testnet-config.json"
 pidfile="/var/run/cardano-node.pid"
 logfile="/var/log/cardano-node.log"
-flags=run +RTS -N -A64m -n4m -F1.2 -qg1 -RTS \
+flags="run +RTS -N -A64m -n4m -F1.2 -qg1 -RTS \
         --database-path ${cardano_node_db} \
         --host-addr ${cardano_node_host} \
         --port ${cardano_node_port} \
         --socket-path ${cardano_node_socket} \
         --topology ${cardano_node_topology} \
         --config ${cardano_node_config} \
-        ${cardano_node_flags}
+        ${cardano_node_flags}"
 
 cardano_node_prestart()
 {


### PR DESCRIPTION
cabal build all on aarm64 fails to compile due to criterion-measurement-0.1.3.0 library 
"cbits/cycles.c:64:2: error: Unsupported OS/architechture/compiler!"

change to build only cardano-node and cardano-cli instead of build all, results in successful build.

Tested on FreeBSD 13.1 aarm64