### PR TITLE
move sock to /socket/ jail dir

### DIFF
--- a/net-p2p/cardano-node/files/cardano_node.in
+++ b/net-p2p/cardano-node/files/cardano_node.in
@@ -177,8 +177,8 @@ cardano_node_prestart()
         mkdir -p "${cardano_node_home}/logs"
     fi
     # Remove socket file, if there is no pid file
-    if [ -S "${jail_socket}" -a ! -f $pidfile ]; then
-        rm "${jail_socket}"
+    if [ -S "${cardano_node_jail}/${jail_socket}" -a ! -f $pidfile ]; then
+        rm "${cardano_node_jail}/${jail_socket}"
     fi
     # Remove the symlink to the socket file too
     if [ -L "${cardano_node_socket}" -a ! -f $pidfile ]; then
@@ -201,7 +201,7 @@ cardano_node_start()
     cd $cardano_node_home && /usr/sbin/daemon -p $pidfile -o ${logfile} \
         ${jail_cmd} command=/bin/cardano-node ${flags} 2>&1 > /dev/null
         # ${jail_cmd} persist
-    ln -s "${jail_socket}" "${cardano_node_socket}"
+    ln -s "${cardano_node_jail}/${jail_socket}" "${cardano_node_socket}"
 }
 
 cardano_node_stop()

--- a/net-p2p/cardano-node/files/cardano_node.in
+++ b/net-p2p/cardano-node/files/cardano_node.in
@@ -83,6 +83,7 @@ load_rc_config $name
 cardano_node_jail="${cardano_node_home}/jail"
 jail_topology="/topology_dir/`basename ${cardano_node_topology}`"
 jail_config="/config_dir/`basename ${cardano_node_config}`"
+jail_socket="/socket/`basename ${cardano_node_socket}`"
 # TODO: exec.jail_user=cardano
 jail_cmd="jail -c name=${name}_jail path=${cardano_node_jail} ip4=inherit ip6=inherit host=inherit"
 
@@ -92,7 +93,7 @@ flags="run +RTS ${cardano_node_rts_flags} -RTS \
         --database-path /db \
         --host-addr ${cardano_node_host} \
         --port ${cardano_node_port} \
-        --socket-path /cardano-node.sock \
+        --socket-path ${jail_socket} \
         --topology ${jail_topology} \
         --config ${jail_config} \
         ${cardano_node_flags}"
@@ -114,7 +115,7 @@ sanity_check()
     return 0
 }
 
-_jail_dirs="/bin /etc /lib /libexec"
+_jail_dirs="/bin /etc /lib /libexec /socket"
 _jail_mount_points="/dev /config_dir /topology_dir /db /logs"
 
 create_jail()
@@ -176,8 +177,8 @@ cardano_node_prestart()
         mkdir -p "${cardano_node_home}/logs"
     fi
     # Remove socket file, if there is no pid file
-    if [ -S "${cardano_node_jail}/cardano-node.sock" -a ! -f $pidfile ]; then
-        rm "${cardano_node_jail}/cardano-node.sock"
+    if [ -S "${cardano_node_jail}/socket/cardano-node.sock" -a ! -f $pidfile ]; then
+        rm "${cardano_node_jail}/socket/cardano-node.sock"
     fi
     # Remove the symlink to the socket file too
     if [ -L "${cardano_node_socket}" -a ! -f $pidfile ]; then
@@ -200,7 +201,7 @@ cardano_node_start()
     cd $cardano_node_home && /usr/sbin/daemon -p $pidfile -o ${logfile} \
         ${jail_cmd} command=/bin/cardano-node ${flags} 2>&1 > /dev/null
         # ${jail_cmd} persist
-    ln -s "${cardano_node_jail}/cardano-node.sock" "${cardano_node_socket}"
+    ln -s "${cardano_node_jail}/socket/cardano-node.sock" "${cardano_node_socket}"
 }
 
 cardano_node_stop()

--- a/net-p2p/cardano-node/files/cardano_node.in
+++ b/net-p2p/cardano-node/files/cardano_node.in
@@ -176,11 +176,8 @@ cardano_node_prestart()
     if [ ! -d "${cardano_node_home}/logs" ]; then
         mkdir -p "${cardano_node_home}/logs"
     fi
-    # Remove socket file, if there is no pid file
-    if [ -S "${cardano_node_jail}/${jail_socket}" -a ! -f $pidfile ]; then
-        rm "${cardano_node_jail}/${jail_socket}"
-    fi
-    # Remove the symlink to the socket file too
+    
+    # Remove the symlink to the socket file if there is no pid file
     if [ -L "${cardano_node_socket}" -a ! -f $pidfile ]; then
         rm "${cardano_node_socket}"
     fi
@@ -200,7 +197,6 @@ cardano_node_start()
     fi
     cd $cardano_node_home && /usr/sbin/daemon -p $pidfile -o ${logfile} \
         ${jail_cmd} command=/bin/cardano-node ${flags} 2>&1 > /dev/null
-        # ${jail_cmd} persist
     ln -s "${cardano_node_jail}/${jail_socket}" "${cardano_node_socket}"
 }
 

--- a/net-p2p/cardano-node/files/cardano_node.in
+++ b/net-p2p/cardano-node/files/cardano_node.in
@@ -177,8 +177,8 @@ cardano_node_prestart()
         mkdir -p "${cardano_node_home}/logs"
     fi
     # Remove socket file, if there is no pid file
-    if [ -S "${cardano_node_jail}/socket/cardano-node.sock" -a ! -f $pidfile ]; then
-        rm "${cardano_node_jail}/socket/cardano-node.sock"
+    if [ -S "${jail_socket}" -a ! -f $pidfile ]; then
+        rm "${jail_socket}"
     fi
     # Remove the symlink to the socket file too
     if [ -L "${cardano_node_socket}" -a ! -f $pidfile ]; then
@@ -201,7 +201,7 @@ cardano_node_start()
     cd $cardano_node_home && /usr/sbin/daemon -p $pidfile -o ${logfile} \
         ${jail_cmd} command=/bin/cardano-node ${flags} 2>&1 > /dev/null
         # ${jail_cmd} persist
-    ln -s "${cardano_node_jail}/socket/cardano-node.sock" "${cardano_node_socket}"
+    ln -s "${jail_socket}" "${cardano_node_socket}"
 }
 
 cardano_node_stop()


### PR DESCRIPTION
Integrating ogmios and cardano-db-sync will require these changes, unless we want to mount whole jail root dir ( bad idea )